### PR TITLE
feat: helper_script: try without lib prefix.

### DIFF
--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -210,6 +210,23 @@ class HelperScript:
         )  # TODO: regex highlight in these matched strings?
         return version_strings
 
+    def remove_digits(self, product_name: str) -> str:
+        """
+        tries to remove digits from product name
+        Example: testpkg1.2-3.4 becomes testpkg
+        """
+        # try removing numeric characters from the product_name
+        LOGGER.debug(
+            f"removing digits from product_name={product_name}"
+        )
+        result = "".join(
+            filter(lambda x: not x.isdigit(), product_name)
+        )
+
+        # skip trailing characters that can often happen after digits removal
+        return result.rstrip("-_. ")
+
+
     def parse_filename(self, filename: str) -> tuple[str, str]:
         """
         returns package_name/product_name from package_filename of types .rpm, .deb, etc.
@@ -226,7 +243,7 @@ class HelperScript:
                 product_name = filename.rsplit("-", 3)[0]
                 version_number = filename.rsplit("-", 3)[1]
                 # example: libarchive-3.5.1-1-aarch64.pkg.tar.xz
-            elif filename.endswith(".deb") or filename.endswith(".ipk"):
+            elif "_" in filename:
                 product_name = filename.rsplit("_")[0]
                 version_number = filename.rsplit("_")[1].rsplit("-")[0].rsplit("+")[0]
                 # example: varnish_6.4.0-3_amd64.deb
@@ -240,22 +257,55 @@ class HelperScript:
             if not self.version_number:
                 self.version_number = version_number
 
-            self.vendor_product = self.find_vendor_product()
-
             LOGGER.debug(
                 f"Parsing file '{filename}': Results: product_name='{self.product_name}', version_number='{self.version_number}'"
             )
-            return product_name, version_number
+
+            # first try
+            self.vendor_product = self.find_vendor_product(self.product_name)
+            if self.vendor_product:
+                return product_name, version_number
+            # failed, check lib prefix
+            if self.product_name.startswith("lib"):
+                # try without lib prefix
+                LOGGER.debug(
+                    f"trying without lib in product_name={self.product_name}"
+                )
+                name_no_lib = self.product_name[3:]
+                self.vendor_product = self.find_vendor_product(name_no_lib)
+                if self.vendor_product:
+                    return product_name, version_number
+                # try without lib prefix and digits
+                if any(char.isdigit() for char in name_no_lib):
+                    self.vendor_product = self.find_vendor_product(self.remove_digits(name_no_lib))
+                    if self.vendor_product:
+                        return product_name, version_number
+            # try without numeric characters
+            if any(char.isdigit() for char in self.product_name):
+                    self.vendor_product = self.find_vendor_product(self.remove_digits(self.product_name))
+                    if self.vendor_product:
+                        return product_name, version_number
+            # all attempts failed, raise error and ask for product_name
+            LOGGER.warning(
+                textwrap.dedent(
+                    f"""
+                        =================================================================
+                        No match was found for "{self.product_name}" in database.
+                        Please check your file or try specifying the "product_name" also.
+                        =================================================================
+                    """
+                )
+            )
         else:
             # raise error for unknown archive types
             with ErrorHandler(mode=ErrorMode.NoTrace, logger=LOGGER):
                 raise UnknownArchiveType(filename)
 
-    def find_vendor_product(self) -> list[tuple[str, str]]:
+    def find_vendor_product(self, product_name) -> list[tuple[str, str]]:
         """find vendor-product pairs from database"""
 
         LOGGER.debug(
-            f"checking for product_name='{self.product_name}' and version_name='{self.version_number}' in the database"
+            f"checking for product_name='{product_name}' and version_name='{self.version_number}' in the database"
         )
 
         cursor = CVEDB.db_open_and_get_cursor(self)
@@ -268,7 +318,7 @@ class HelperScript:
         if cursor is None:
             return []
 
-        cursor.execute(query, {"product": self.product_name})
+        cursor.execute(query, {"product": product_name})
         data = cursor.fetchall()
 
         # checking if (vendor, product) was found in the database
@@ -280,40 +330,21 @@ class HelperScript:
                     textwrap.dedent(
                         f"""
                             ===============================================================
-                            Multiple ("vendor", "product") pairs found for "{self.product_name}"
+                            Multiple ("vendor", "product") pairs found for "{product_name}"
                             Please manually select the appropriate pair.
                             ===============================================================
                         """
                     )
                 )
                 WARNED = True  # prevent same warning multiple times
+
+            # we found correct product_name, set it
+            self.product_name = product_name
             return data  # [('vendor', 'product')]
-        else:
-            if self.product_name:
-                # removing numeric characters from the product_name
-                if any(char.isdigit() for char in self.product_name):
-                    LOGGER.debug(
-                        f"removing digits from product_name={self.product_name}"
-                    )
-                    self.product_name = "".join(
-                        filter(lambda x: not x.isdigit(), self.product_name)
-                    )
-                    return self.find_vendor_product()
-                else:
-                    # raise error and ask for product_name
-                    LOGGER.warning(
-                        textwrap.dedent(
-                            f"""
-                                =================================================================
-                                No match was found for "{self.product_name}" in database.
-                                Please check your file or try specifying the "product_name" also.
-                                =================================================================
-                            """
-                        )
-                    )
-                    return []
 
         CVEDB.db_close(self)  # type: ignore
+
+        return []
 
     def output_single(self) -> None:
         """display beautiful output for Helper-Script"""


### PR DESCRIPTION
Change helper_script behavior to also try to search using predicted name without "lib" prefix.
Also added small trim to avoid trying package names like "libtest-" which happen pretty often after numeric characters removal.
Additional change: rely on "_" if "_" exist in name, not on extension. For example, there are multiple rpm packages which also use _ to separate name of version.